### PR TITLE
help text can now switch modes to demonstrate the text better

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -176,6 +176,7 @@ button.active {
     border: 3px solid #4caf50;
     width: 50%;
     height: 90%;
+    border-radius: 10px;
 }
 
 #helpBox {
@@ -185,4 +186,10 @@ button.active {
 
 #helpText {
     overflow: auto;
+}
+
+.helpLink:hover {
+    background-color: #4caf50;
+    border-radius: 5px;
+    cursor: pointer;
 }

--- a/js/events.js
+++ b/js/events.js
@@ -15,6 +15,10 @@ document.getElementById("floorplanButton").addEventListener("click", changeToFlo
 document.getElementById("roomButton").addEventListener("click", changeToRoomMode);
 document.getElementById("furnitureButton").addEventListener("click", changeToFurnitureMode);
 document.getElementById("presentationButton").addEventListener("click", changeToPresentationMode);
+function clickFloorplan() { document.getElementById("floorplanButton").click(); }
+function clickRoom() { document.getElementById("roomButton").click(); }
+function clickFurniture() { document.getElementById("furnitureButton").click(); }
+function clickDisplay() { document.getElementById("presentationButton").click(); }
 function changeMode(e, mode) {
     resetElements("mode");
     settings.mode = mode;

--- a/js/init.js
+++ b/js/init.js
@@ -46,6 +46,13 @@ function addListEntry(parent, type, head, short) {
     elem.appendChild(headElem);
     elem.appendChild(shortElem);
     parent.appendChild(elem);
+    return headElem;
+}
+function addAttr(elem, attr) {
+    for (const [key, value] of Object.entries(attr)) {
+        elem.setAttribute(key, value);
+    }
+    return elem;
 }
 function setButtonContent() {
     // floorplan
@@ -100,26 +107,25 @@ function setButtonContent() {
     addElem(helpText, "p", loc.help.intro);
     addElem(helpText, "p", loc.help.explanationMode);
     const modeList = addElem(helpText, "ul");
-    addListEntry(modeList, "li", loc.help.introFloorplan, loc.help.shortFloorplan);
-    addListEntry(modeList, "li", loc.help.introRoom, loc.help.shortRoom);
-    addListEntry(modeList, "li", loc.help.introFurniture, loc.help.shortFurniture);
-    addListEntry(modeList, "li", loc.help.introDisplay, loc.help.shortDisplay);
+    addAttr(addListEntry(modeList, "li", loc.help.introFloorplan, loc.help.shortFloorplan), { "class": "helpLink" }).addEventListener("click", clickFloorplan);
+    addAttr(addListEntry(modeList, "li", loc.help.introRoom, loc.help.shortRoom), { "class": "helpLink" }).addEventListener("click", clickRoom);
+    addAttr(addListEntry(modeList, "li", loc.help.introFurniture, loc.help.shortFurniture), { "class": "helpLink" }).addEventListener("click", clickFurniture);
+    addAttr(addListEntry(modeList, "li", loc.help.introDisplay, loc.help.shortDisplay), { "class": "helpLink" }).addEventListener("click", clickDisplay);
     addElem(helpText, "p", loc.help.explanationUtil);
     const utilList = addElem(helpText, "ul");
     addListEntry(utilList, "li", loc.fileIO.saveButton, loc.fileIO.saveShort);
     addListEntry(utilList, "li", loc.fileIO.loadButton, loc.fileIO.loadShort);
     addListEntry(utilList, "li", loc.fileIO.exportButton, loc.fileIO.exportShort);
     addListEntry(utilList, "li", loc.fileIO.printButton, loc.fileIO.printShort);
-    addElem(helpText, "h3", loc.help.introFloorplan);
+    addAttr(addElem(helpText, "h3", loc.help.introFloorplan), { "class": "helpLink" }).addEventListener("click", clickFloorplan);
     addElem(helpText, "p", loc.help.explanationFloorplan);
-    addElem(helpText, "h3", loc.help.introRoom);
+    addAttr(addElem(helpText, "h3", loc.help.introRoom), { "class": "helpLink" }).addEventListener("click", clickRoom);
     addElem(helpText, "p", loc.help.explanationRoom);
-    addElem(helpText, "h3", loc.help.introFurniture);
+    addAttr(addElem(helpText, "h3", loc.help.introFurniture), { "class": "helpLink" }).addEventListener("click", clickFurniture);
     addElem(helpText, "p", loc.help.explanationFurniture);
-    addElem(helpText, "h3", loc.help.introDisplay);
+    addAttr(addElem(helpText, "h3", loc.help.introDisplay), { "class": "helpLink" }).addEventListener("click", clickDisplay);
     addElem(helpText, "p", loc.help.explanationDisplay);
-    const creatorElem = addElem(helpText, "p");
-    addElem(creatorElem, "b", loc.help.creator);
+    addElem(addElem(helpText, "p"), "b", loc.help.creator);
     document.getElementById("helpClose").textContent = getText(loc.help.helpClose);
 }
 window.addEventListener("resize", setSize);
@@ -152,7 +158,7 @@ function init() {
     }
     console.log("language:", settings.language);
     document.getElementById("distanceInput").dispatchEvent(new Event("input"));
-    document.getElementById("roomButton").click();
+    clickRoom();
     document.getElementById("leftOpenableButton").click();
     document.getElementById("circleButton").click();
     initNodeSize();

--- a/ts/events.ts
+++ b/ts/events.ts
@@ -17,6 +17,11 @@ document.getElementById("roomButton")!.addEventListener("click", changeToRoomMod
 document.getElementById("furnitureButton")!.addEventListener("click", changeToFurnitureMode);
 document.getElementById("presentationButton")!.addEventListener("click", changeToPresentationMode);
 
+function clickFloorplan() { document.getElementById("floorplanButton")!.click(); }
+function clickRoom() { document.getElementById("roomButton")!.click(); }
+function clickFurniture() { document.getElementById("furnitureButton")!.click(); }
+function clickDisplay() { document.getElementById("presentationButton")!.click(); }
+
 function changeMode(e: MouseEvent, mode: Mode) {
     resetElements("mode");
 

--- a/ts/init.ts
+++ b/ts/init.ts
@@ -51,7 +51,7 @@ function addElem(parent: HTMLElement, type: string, text: Localization | null = 
     return elem;
 }
 
-function addListEntry(parent: HTMLElement, type: string, head: Localization, short: Localization) {
+function addListEntry(parent: HTMLElement, type: string, head: Localization, short: Localization): HTMLElement {
     const elem = document.createElement(type);
     const headElem = document.createElement("b");
     headElem.textContent = getText(head) + ": ";
@@ -60,6 +60,15 @@ function addListEntry(parent: HTMLElement, type: string, head: Localization, sho
     elem.appendChild(shortElem);
 
     parent.appendChild(elem);
+
+    return headElem;
+}
+
+function addAttr(elem: HTMLElement, attr: { [key: string]: string }): HTMLElement {
+    for (const [key, value] of Object.entries(attr)) {
+        elem.setAttribute(key, value);
+    }
+    return elem;
 }
 
 function setButtonContent() {
@@ -136,10 +145,10 @@ function setButtonContent() {
 
     addElem(helpText, "p", loc.help.explanationMode);
     const modeList: HTMLUListElement = addElem(helpText, "ul") as HTMLUListElement;
-    addListEntry(modeList, "li", loc.help.introFloorplan, loc.help.shortFloorplan);
-    addListEntry(modeList, "li", loc.help.introRoom, loc.help.shortRoom);
-    addListEntry(modeList, "li", loc.help.introFurniture, loc.help.shortFurniture);
-    addListEntry(modeList, "li", loc.help.introDisplay, loc.help.shortDisplay);
+    addAttr(addListEntry(modeList, "li", loc.help.introFloorplan, loc.help.shortFloorplan), { "class": "helpLink" }).addEventListener("click", clickFloorplan);
+    addAttr(addListEntry(modeList, "li", loc.help.introRoom, loc.help.shortRoom), { "class": "helpLink" }).addEventListener("click", clickRoom);
+    addAttr(addListEntry(modeList, "li", loc.help.introFurniture, loc.help.shortFurniture), { "class": "helpLink" }).addEventListener("click", clickFurniture);
+    addAttr(addListEntry(modeList, "li", loc.help.introDisplay, loc.help.shortDisplay), { "class": "helpLink" }).addEventListener("click", clickDisplay);
 
     addElem(helpText, "p", loc.help.explanationUtil);
     const utilList: HTMLUListElement = addElem(helpText, "ul") as HTMLUListElement;
@@ -148,17 +157,19 @@ function setButtonContent() {
     addListEntry(utilList, "li", loc.fileIO.exportButton, loc.fileIO.exportShort);
     addListEntry(utilList, "li", loc.fileIO.printButton, loc.fileIO.printShort);
 
-    addElem(helpText, "h3", loc.help.introFloorplan);
+    addAttr(addElem(helpText, "h3", loc.help.introFloorplan), { "class": "helpLink" }).addEventListener("click", clickFloorplan);
     addElem(helpText, "p", loc.help.explanationFloorplan);
-    addElem(helpText, "h3", loc.help.introRoom);
+
+    addAttr(addElem(helpText, "h3", loc.help.introRoom), { "class": "helpLink" }).addEventListener("click", clickRoom);
     addElem(helpText, "p", loc.help.explanationRoom);
-    addElem(helpText, "h3", loc.help.introFurniture);
+
+    addAttr(addElem(helpText, "h3", loc.help.introFurniture), { "class": "helpLink" }).addEventListener("click", clickFurniture);
     addElem(helpText, "p", loc.help.explanationFurniture);
-    addElem(helpText, "h3", loc.help.introDisplay);
+
+    addAttr(addElem(helpText, "h3", loc.help.introDisplay), { "class": "helpLink" }).addEventListener("click", clickDisplay);
     addElem(helpText, "p", loc.help.explanationDisplay);
 
-    const creatorElem = addElem(helpText, "p");
-    addElem(creatorElem, "b", loc.help.creator);
+    addElem(addElem(helpText, "p"), "b", loc.help.creator);
 
     document.getElementById("helpClose")!.textContent = getText(loc.help.helpClose);
 }
@@ -202,7 +213,7 @@ function init() {
 
     document.getElementById("distanceInput")!.dispatchEvent(new Event("input"));
 
-    document.getElementById("roomButton")!.click();
+    clickRoom();
 
     document.getElementById("leftOpenableButton")!.click();
 


### PR DESCRIPTION
Minor work on help text with references to modes:
![help0](https://github.com/karldaeubel/PenAndPaperFloorplanner/assets/1245268/06c48b51-ff31-4fe9-9082-db5eae598d6e)
![help1](https://github.com/karldaeubel/PenAndPaperFloorplanner/assets/1245268/2735328c-1103-4d6c-ae8c-8c6e2c2ff9f3)
