### PR TITLE
add room size option

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,10 @@
                         <td><input type="checkbox" id="edgeLabelCheckbox" class="checkboxClass"></td>
                         <td><label id="edgeLabelCheckboxLabel" for="edgeLabelCheckbox"></label></td>
                     </tr>
+                    <tr>
+                        <td><input type="checkbox" id="roomSizeCheckbox" class="checkboxClass"></td>
+                        <td><label id="roomSizeCheckboxLabel" for="roomSizeCheckbox"></label></td>
+                    </tr>
                 </table>
             </div>
             <div id="bottomMenu" class="buttonRow">

--- a/js/defs.js
+++ b/js/defs.js
@@ -85,6 +85,7 @@ const settings = {
     furnitureRotateSize: 100,
     furnitureSnapAngle: 5,
     showEdgeLabels: false,
+    showRoomSize: false,
 };
 // state will lazily track changes since init or last save/load as string
 let state = null;

--- a/js/draw.js
+++ b/js/draw.js
@@ -1,8 +1,8 @@
 "use strict";
 // utils
-function setFontSize(size, fixed = true) {
+function setFontSize(size, fixed = true, bold = false) {
     const proj = settings.mode === Mode.Floorplan ? floorplanProjection : projection;
-    ctx.font = (size / (fixed ? 1 : proj.scale)) + "px Segoe UI, Segoe UI, sans-serif";
+    ctx.font = (bold ? "normal 900 " : "") + (size / (fixed ? 1 : proj.scale)) + "px Segoe UI, Segoe UI, sans-serif";
 }
 function restoreDefaultContext() {
     const proj = settings.mode === Mode.Floorplan ? floorplanProjection : projection;

--- a/js/events.js
+++ b/js/events.js
@@ -232,3 +232,7 @@ document.getElementById("edgeLabelCheckbox").addEventListener("change", (e) => {
     settings.showEdgeLabels = e.target.checked;
     drawMain();
 });
+document.getElementById("roomSizeCheckbox").addEventListener("change", (e) => {
+    settings.showRoomSize = e.target.checked;
+    drawMain();
+});

--- a/js/init.js
+++ b/js/init.js
@@ -26,9 +26,11 @@ function setNodeExtendSize() {
     transSlider.value = String(settings.nodeTransSize);
     drawMain();
 }
-function resetEdgeLabelCheckBox() {
+function resetOptions() {
     settings.showEdgeLabels = false;
     document.getElementById("edgeLabelCheckbox").checked = false;
+    settings.showRoomSize = false;
+    document.getElementById("roomSizeCheckbox").checked = false;
 }
 function addElem(parent, type, text = null) {
     const elem = document.createElement(type);
@@ -94,7 +96,8 @@ function setButtonContent() {
     // presentation
     document.getElementById("presentationButton").textContent = getText(loc.presentation.category);
     document.getElementById("presentationOptionsHead").textContent = getText(loc.presentation.option.head);
-    document.getElementById("edgeLabelCheckboxLabel").textContent = getText(loc.presentation.option.shwoEdgeLabel);
+    document.getElementById("edgeLabelCheckboxLabel").textContent = getText(loc.presentation.option.showEdgeLabel);
+    document.getElementById("roomSizeCheckboxLabel").textContent = getText(loc.presentation.option.roomSizeLabel);
     // util
     document.getElementById("saveButton").textContent = getText(loc.fileIO.saveButton);
     document.getElementById("loadButton").textContent = getText(loc.fileIO.loadButton);
@@ -165,5 +168,5 @@ function init() {
     setButtonContent();
     setState();
     setSize();
-    resetEdgeLabelCheckBox();
+    resetOptions();
 }

--- a/js/localization.js
+++ b/js/localization.js
@@ -338,10 +338,14 @@ const loc = {
                 en: "Global Options",
                 de: "Globale Einstellungen"
             },
-            shwoEdgeLabel: {
+            showEdgeLabel: {
                 en: "Show Wall Length",
                 de: "Zeige Wandlänge"
-            }
+            },
+            roomSizeLabel: {
+                en: "Show Room Size",
+                de: "Zeige Raumgröße"
+            },
         },
     },
 };

--- a/js/utils.js
+++ b/js/utils.js
@@ -43,3 +43,6 @@ function getIntersectionPoint(center, border, wall1, wall2) {
     }
     return null;
 }
+function getTrapezoidArea(p1, p2) {
+    return (p1.x - p2.x) * (p1.y + p2.y) / 2;
+}

--- a/ts/defs.ts
+++ b/ts/defs.ts
@@ -87,6 +87,7 @@ interface Settings {
     readonly furnitureSnapAngle: number,
 
     showEdgeLabels: boolean,
+    showRoomSize: boolean,
 };
 
 const settings: Settings = {
@@ -110,6 +111,7 @@ const settings: Settings = {
     furnitureSnapAngle: 5,
 
     showEdgeLabels: false,
+    showRoomSize: false,
 };
 
 type optionalPoint = { x: optionalNumber, y: optionalNumber };

--- a/ts/draw.ts
+++ b/ts/draw.ts
@@ -1,7 +1,7 @@
 // utils
-function setFontSize(size: number, fixed: boolean = true) {
+function setFontSize(size: number, fixed: boolean = true, bold: boolean = false) {
     const proj = settings.mode === Mode.Floorplan ? floorplanProjection : projection;
-    ctx.font = (size / (fixed ? 1 : proj.scale)) + "px Segoe UI, Segoe UI, sans-serif";
+    ctx.font = (bold ? "normal 900 " : "") + (size / (fixed ? 1 : proj.scale)) + "px Segoe UI, Segoe UI, sans-serif";
 }
 
 function restoreDefaultContext() {

--- a/ts/events.ts
+++ b/ts/events.ts
@@ -282,3 +282,9 @@ document.getElementById("edgeLabelCheckbox")!.addEventListener("change", (e) => 
 
     drawMain();
 });
+
+document.getElementById("roomSizeCheckbox")!.addEventListener("change", (e) => {
+    settings.showRoomSize = (e.target as HTMLInputElement).checked;
+
+    drawMain();
+});

--- a/ts/graph.ts
+++ b/ts/graph.ts
@@ -71,6 +71,8 @@ interface Graph {
     mergeNodes: (fromId: number, toId: number) => void,
     bisect: (id: number, edge: Edge, pos: number) => void,
 
+    getFaces: () => CornerNode[][],
+
     reset: () => void,
 
     nextEdgeToSegment: (center: Point, p: Point) => Point | null,
@@ -85,6 +87,7 @@ interface Graph {
     handleUnclick: (e: Point) => void,
 
     draw: () => void,
+    drawFaces: () => void,
     drawEdges: () => void,
     drawNodes: () => void,
     drawExtend: () => void,
@@ -428,6 +431,73 @@ const graph: Graph = {
             }
         }
     },
+    getFaces: function (): CornerNode[][] {
+        let directedEdges: [number, number][] = [];
+
+        let allEdges: { [key: number]: number[] } = {};
+
+        for (const outEdges of Object.values(this.edges)) {
+            for (const edge of Object.values(outEdges)) {
+                directedEdges.push([edge.id1, edge.id2]);
+                directedEdges.push([edge.id2, edge.id1]);
+
+                allEdges[edge.id1] = allEdges[edge.id1] || [];
+                allEdges[edge.id2] = allEdges[edge.id2] || [];
+
+                allEdges[edge.id1]!.push(edge.id2);
+                allEdges[edge.id2]!.push(edge.id1);
+            }
+        }
+
+        let nextEdge: { [key: number]: { [key: number]: number } } = {};
+        Object.entries(allEdges).forEach(
+            ([id1S, outEdges]) => {
+                if (outEdges.length === 0) {
+                    return;
+                }
+                // wtf; why can I not access the key as number here...
+                const id1 = Number(id1S);
+                const currNode = this.nodes[id1] as CornerNode;
+                outEdges.sort(
+                    (other1: number, other2: number) => {
+                        const otherNode1 = this.nodes[other1] as CornerNode;
+                        const otherNode2 = this.nodes[other2] as CornerNode;
+                        const angle1 = Math.atan2(otherNode1.p.y - currNode.p.y, otherNode1.p.x - currNode.p.x);
+                        const angle2 = Math.atan2(otherNode2.p.y - currNode.p.y, otherNode2.p.x - currNode.p.x);
+                        return angle1 - angle2;
+                    }
+                );
+                nextEdge[id1] = nextEdge[id1] || {};
+                nextEdge[id1]![outEdges.at(0)!] = outEdges.at(outEdges.length - 1) as number;
+                for (let idx: number = 1; idx < outEdges.length; ++idx) {
+                    const id2 = outEdges[idx] as number;
+                    nextEdge[id1]![id2] = outEdges.at(idx - 1) as number;
+                }
+            }
+        );
+
+        let result: CornerNode[][] = [];
+        while (directedEdges.length > 0) {
+            let currFace = result.at(result.push([]) - 1) as CornerNode[];
+            const [id1, id2] = directedEdges.at(0) as [number, number];
+            let currNode = this.nodes[id1] as CornerNode;
+            let nextNode = this.nodes[id2] as CornerNode;
+
+            currFace.push(currNode);
+            let removeIdx: number = -1;
+            while ((removeIdx = directedEdges.findIndex((val) => val.at(0) === currNode.id && val.at(1) === nextNode.id)) !== -1) {
+                currFace.push(nextNode);
+
+                directedEdges.splice(removeIdx, 1);
+
+                const nextId = nextEdge[nextNode.id]![currNode.id] as number;
+                currNode = nextNode;
+                nextNode = this.nodes[nextId] as CornerNode;
+            }
+        }
+
+        return result;
+    },
     // e, the click position; e is in screen space
     handleClick: function (e: Point): boolean {
         let selected = false;
@@ -530,11 +600,50 @@ const graph: Graph = {
     draw: function () {
         this.drawEdges();
 
+        if (settings.showRoomSize) {
+            this.drawFaces();
+        }
+
         if (settings.mode === Mode.Room) {
             this.drawNodes();
 
             this.drawExtend();
         }
+    },
+    drawFaces: function () {
+        const faces = this.getFaces();
+
+        setFontSize(22, false, true);
+        ctx.fillStyle = "lightgray";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+
+        for (const face of faces) {
+            if (face.length < 2) { continue; }
+
+            let area: number = 0;
+            let mid: Point = { x: 0, y: 0 };
+            let prevP: Point = face.at(0)!.p;
+            for (let i = 1; i < face.length; ++i) {
+                const currP: Point = face.at(i)!.p;
+                area += getTrapezoidArea(prevP, currP);
+                mid = {
+                    x: mid.x + (prevP.x + currP.x) * (prevP.x * currP.y - currP.x * prevP.y),
+                    y: mid.y + (prevP.y + currP.y) * (prevP.x * currP.y - currP.x * prevP.y),
+                };
+                prevP = currP;
+            }
+            mid = {
+                x: mid.x / (6 * area),
+                y: mid.y / (6 * area),
+            }
+            area /= 1000 * 1000;
+
+            if (area <= 0) { continue; }
+
+            ctx.fillText(area.toFixed(1) + "m²", mid.x, mid.y);
+        }
+        restoreDefaultContext()
     },
     drawEdges: function () {
         for (const outEdges of Object.values(this.edges)) {

--- a/ts/init.ts
+++ b/ts/init.ts
@@ -37,9 +37,12 @@ function setNodeExtendSize() {
     drawMain();
 }
 
-function resetEdgeLabelCheckBox() {
+function resetOptions() {
     settings.showEdgeLabels = false;
     (document.getElementById("edgeLabelCheckbox") as HTMLInputElement).checked = false;
+
+    settings.showRoomSize = false;
+    (document.getElementById("roomSizeCheckbox") as HTMLInputElement).checked = false;
 }
 
 function addElem(parent: HTMLElement, type: string, text: Localization | null = null): HTMLElement {
@@ -128,7 +131,8 @@ function setButtonContent() {
     document.getElementById("presentationButton")!.textContent = getText(loc.presentation.category);
 
     document.getElementById("presentationOptionsHead")!.textContent = getText(loc.presentation.option.head);
-    document.getElementById("edgeLabelCheckboxLabel")!.textContent = getText(loc.presentation.option.shwoEdgeLabel);
+    document.getElementById("edgeLabelCheckboxLabel")!.textContent = getText(loc.presentation.option.showEdgeLabel);
+    document.getElementById("roomSizeCheckboxLabel")!.textContent = getText(loc.presentation.option.roomSizeLabel);
 
     // util
     document.getElementById("saveButton")!.textContent = getText(loc.fileIO.saveButton);
@@ -227,5 +231,5 @@ function init() {
 
     setSize();
 
-    resetEdgeLabelCheckBox();
+    resetOptions();
 }

--- a/ts/localization.ts
+++ b/ts/localization.ts
@@ -344,10 +344,14 @@ const loc = {
                 en: "Global Options",
                 de: "Globale Einstellungen"
             },
-            shwoEdgeLabel: {
+            showEdgeLabel: {
                 en: "Show Wall Length",
                 de: "Zeige Wandlänge"
-            }
+            },
+            roomSizeLabel: {
+                en: "Show Room Size",
+                de: "Zeige Raumgröße"
+            },
         },
     },
 };

--- a/ts/utils.ts
+++ b/ts/utils.ts
@@ -50,3 +50,7 @@ function getIntersectionPoint(center: Point, border: Point, wall1: Point, wall2:
     }
     return null;
 }
+
+function getTrapezoidArea(p1: Point, p2: Point): number {
+    return (p1.x - p2.x) * (p1.y + p2.y) / 2;
+}


### PR DESCRIPTION
Room size is now supported. Every closed room can now display its size. 

Limitations: 
Rooms size of 'enclosed' rooms is not considered (rooms that are not connected and are nested within each other);
Room size of 'non-planar' room embeddings (rooms with crossing walls)

![Screenshot_2023-10-23_02-05-21](https://github.com/karldaeubel/PenAndPaperFloorplanner/assets/1245268/63ff1a0b-dff1-4266-b248-2458f9e9925e)
